### PR TITLE
Initial refactoring of zone file generation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -85,15 +85,16 @@ gdnsd__expire: '1w'
 gdnsd__negative_cache: '1h'
 
 
-# .. envvar:: gdnsd__reverse_zones
+# .. envvar:: gdnsd__auto_reverse_zone
 #
-# Support reverse zones. Set this to ``False`` in case reverse name lookup
-# should not be supported.
-gdnsd__reverse_zones: True
+# Automatically generate reverse zones for defined domains. This can be
+# overwritten per zone by specificying the ``auto_reverse_zone`` attribute in
+# the zone definition.
+gdnsd__auto_reverse_zone: True
 
 
 # .. envvar:: gdnsd__default_reverse_zone:
 #
-# Default reverse zone. This value is used in case `network` is not specified in the
-# zone definition and :envvar:`gdnsd__reverse_zones` is enabled.
+# Default reverse zone. This value is used if a zone entry has defined
+# ``auto_reverse_zone: True`` but doesn't specify the ``reverse_zone``.
 gdnsd__default_reverse_zone: '{{ ansible_default_ipv4.address.split(".")[:3] | reverse | join(".") }}.in-addr.arpa'

--- a/docs/defaults-detailed.rst
+++ b/docs/defaults-detailed.rst
@@ -22,12 +22,17 @@ YAML dictionary with the following parameters:
 ``domain``
   Domain name of the DNS zone. Required, if this is a forward zone.
 
-``reverse_zone``
-  Optional. Set this to ``True`` to mark zone entry as reverse zone. Defaults
-  to ``False``.
+``auto_reverse_zone``
+  Optional. Automatically generate reverse zone for this domain. Default to
+  :envvar:`gdnsd__auto_reverse_zone`. Individual records can be excluded from
+  the reverse zone by setting ``do_reverse: False`` in the record item
+  definition.
 
-``reverse_network``
-  Network definition for reverse zone. Required, if this is a reverse zone.
+``reverse_zone``
+  Name of the reverse zone (e.g. '1.168.192.in-addr.arpa'). Required if this
+  is a reverse zone. Optional if this is a forward zone that has
+  ``auto_reverse_zone`` enabled. In this case it defaults to
+  :envvar:`gdnsd__default_reverse_zone`.
 
 ``primary_nameserver``
   Optional. DNS name of the primary name server for this zone which is added
@@ -73,7 +78,7 @@ YAML dictionary with the following parameters:
 
   ``do_reverse``
     Optional. If ``item.type`` is ``A``, add a reverse zone entry for this
-    record. Defaults to ``True`` if :envvar:`gdnsd__reverse_zones` is ``True``.
+    record. Defaults to ``True`` if ``auto_reverse_zone: True`` for this zone.
 
   ``target``
     Required. Resource data which is served when querying the record.

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -11,21 +11,30 @@
         auto_reverse_zone: False
       - domain: example.com
         records:
+          # 'A' record
           - name: '{{ ansible_hostname }}'
             target: '{{ ansible_default_ipv4.address }}'
+          # 'AAAA' record
           - name: '@'
             type: AAAA
             target: '2606:2800:220:1:248:1893:25c8:1946'
             do_reverse: false
+          # 'A' record of domain '@'
           - name: '@'
             target: '{{ ansible_default_ipv4.address }}'
             do_reverse: false
+          # 'A' record of wildcard domain
+          - name: '*.apps'
+            target: '{{ ansible_default_ipv4.address }}'
+          # 'CNAME' record
           - name: www
             type: CNAME
             target: example.com
+          # 'TXT' record
           - name: ansible
             type: TXT
             target: "tested-by=molecule"
+          # 'MX' record
           - type: MX
             target: '{{ ansible_default_ipv4.address }}'
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,6 +6,9 @@
     gdnsd__custom_packages:
       - netbase
     gdnsd__zones:
+      # domain without records
+      - domain: example.net
+        auto_reverse_zone: False
       - domain: example.com
         records:
           - name: '{{ ansible_hostname }}'

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -23,7 +23,19 @@
       port: 53
       connect_timeout: 2
 
-  - name: Check DNS records
+  - name: Check example.net DNS records
+    assert:
+      quiet: true
+      that: '{{ item.query == item.response }}'
+    loop:
+      # A domain with no records defined should have at least an 'NS' and an
+      # 'A' record definend of the host itself
+      - query: '{{ lookup("dig", "example.net.", "qtype=NS", "@" + ansible_default_ipv4.address) }}'
+        response: '{{ ansible_hostname }}.example.net.'
+      - query: '{{ lookup("dig", ansible_hostname + ".example.net.", "@" + ansible_default_ipv4.address) }}'
+        response: '{{ ansible_default_ipv4.address }}'
+
+  - name: Check example.com DNS records
     assert:
       quiet: true
       that: '{{ item.query == item.response }}'

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -52,6 +52,8 @@
         response: '{{ ansible_default_ipv4.address }}'
       - query: '{{ lookup("dig", ansible_hostname + ".example.com.", "@" + ansible_default_ipv4.address, wantlist=True) }}'
         response: '{{ [ ansible_default_ipv4.address ] }}'
+      - query: '{{ lookup("dig", "test.apps.example.com.", "@" + ansible_default_ipv4.address) }}'
+        response: '{{ ansible_default_ipv4.address }}'
       - query: '{{ lookup("dig", "example.com.", "qtype=MX", "@" + ansible_default_ipv4.address) }}'
         response: '5 {{ ansible_default_ipv4.address }}.'
       - query: '{{ lookup("dig", "ansible.example.com.", "qtype=TXT", "@" + ansible_default_ipv4.address) }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,16 +20,18 @@
     gdnsd__fact_zone_serial: '{{ ansible_date_time.epoch }}'
   run_once: True
 
-- name: Read forward zone hashes
+- name: Read existing forward zone hashes
   shell: 'grep "^; Hash:" /etc/gdnsd/zones/{{ item.domain }} || true'
   changed_when: False
   check_mode: no
   register: gdnsd__register_forward_hashes
-  when: (not "reverse_zone" in item) or
-        (not item.reverse_zone)
-  with_items: '{{ gdnsd__zones
-                  if (gdnsd__zones|d([]) | length) > 0
-                  else [ {"domain": ansible_domain} ] }}'
+  when: ('domain' in item.keys())
+  # If 'gdnsd__zones' is empty add the domain detected by Ansible
+  loop: '{{ gdnsd__zones
+            if (gdnsd__zones | length) > 0
+            else [ {"domain": ansible_domain} ] }}'
+  loop_control:
+    label: '{{ item.domain }}'
 
 - name: Generate forward zones
   template:
@@ -38,11 +40,12 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  when: (not "reverse_zone" in item) or
-        (not item.reverse_zone)
-  with_items: '{{ gdnsd__zones
-                  if (gdnsd__zones|d([]) | length) > 0
-                  else [ {"domain": ansible_domain} ] }}'
+  when: ('domain' in item.keys())
+  loop: '{{ gdnsd__zones
+            if (gdnsd__zones | length) > 0
+            else [ {"domain": ansible_domain} ] }}'
+  loop_control:
+    label: '{{ item.domain }}'
 
 - name: Read reverse zone hashes
   shell: 'grep "^; Hash:" /etc/gdnsd/zones/{{ gdnsd__default_reverse_zone

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,66 +20,17 @@
     gdnsd__fact_zone_serial: '{{ ansible_date_time.epoch }}'
   run_once: True
 
-- name: Read existing forward zone hashes
-  shell: 'grep "^; Hash:" /etc/gdnsd/zones/{{ item.domain }} || true'
-  changed_when: False
-  check_mode: no
-  register: gdnsd__register_forward_hashes
-  when: ('domain' in item.keys())
-  # If 'gdnsd__zones' is empty add the domain detected by Ansible
+- name: Include tasks for generating zone file
+  include_tasks: zone.yml
   loop: '{{ gdnsd__zones
             if (gdnsd__zones | length) > 0
-            else [ {"domain": ansible_domain} ] }}'
+            else [ {"domain": ansible_domain,
+                    "reverse_zone": gdnsd__default_reverse_zone} ] }}'
   loop_control:
-    label: '{{ item.domain }}'
-
-- name: Generate forward zones
-  template:
-    src: 'etc/gdnsd/zones/forward_zone.j2'
-    dest: '/etc/gdnsd/zones/{{ item.domain }}'
-    owner: 'root'
-    group: 'root'
-    mode: '0644'
-  when: ('domain' in item.keys())
-  loop: '{{ gdnsd__zones
-            if (gdnsd__zones | length) > 0
-            else [ {"domain": ansible_domain} ] }}'
-  loop_control:
-    label: '{{ item.domain }}'
-
-- name: Read reverse zone hashes
-  shell: 'grep "^; Hash:" /etc/gdnsd/zones/{{ gdnsd__default_reverse_zone
-                                              if (not "reverse_zone" in item)
-                                              else item.reverse_zone }} || true'
-  changed_when: False
-  check_mode: no
-  register: gdnsd__register_reverse_hashes
-  when: (item.auto_reverse_zone|d(gdnsd__auto_reverse_zone) and
-         item.domain|d('') | length > 0) or
-        (item.reverse_zone|d('') | length > 0)
-  loop: '{{ gdnsd__zones
-            if (gdnsd__zones | length) > 0
-            else [ {"reverse_zone": gdnsd__default_reverse_zone} ] }}'
-  loop_control:
-    label: '{{ item.reverse_zone|d(gdnsd__default_reverse_zone) }}'
-
-- name: Generate reverse zones
-  template:
-    src: 'etc/gdnsd/zones/reverse_zone.j2'
-    dest: '/etc/gdnsd/zones/{{ gdnsd__default_reverse_zone
-                               if (not "reverse_zone" in item)
-                               else item.reverse_zone }}'
-    owner: 'root'
-    group: 'root'
-    mode: '0644'
-  when: (item.auto_reverse_zone|d(gdnsd__auto_reverse_zone) and
-         item.domain|d('') | length > 0) or
-        (item.reverse_zone|d('') | length > 0)
-  loop: '{{ gdnsd__zones
-            if (gdnsd__zones | length) > 0
-            else [ {"reverse_zone": gdnsd__default_reverse_zone} ] }}'
-  loop_control:
-    label: '{{ item.reverse_zone|d(gdnsd__default_reverse_zone) }}'
+    label: '{{ gdnsd__include_zone.domain
+               if "domain" in gdnsd__include_zone.keys()
+               else gdnsd__include_zone.reverse_zone }}'
+    loop_var: gdnsd__include_zone
 
 - name: Check configuration and zone files
   command: gdnsd -s checkconf  # noqa 301

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,10 +54,14 @@
   changed_when: False
   check_mode: no
   register: gdnsd__register_reverse_hashes
-  when: gdnsd__reverse_zones|d(True)
-  with_items: '{{ gdnsd__zones
-                  if (gdnsd__zones|d([]) | length) > 0
-                  else [ {"reverse_zone": gdnsd__default_reverse_zone} ] }}'
+  when: (item.auto_reverse_zone|d(gdnsd__auto_reverse_zone) and
+         item.domain|d('') | length > 0) or
+        (item.reverse_zone|d('') | length > 0)
+  loop: '{{ gdnsd__zones
+            if (gdnsd__zones | length) > 0
+            else [ {"reverse_zone": gdnsd__default_reverse_zone} ] }}'
+  loop_control:
+    label: '{{ item.reverse_zone|d(gdnsd__default_reverse_zone) }}'
 
 - name: Generate reverse zones
   template:
@@ -68,10 +72,14 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  when: gdnsd__reverse_zones|d(True)
-  with_items: '{{ gdnsd__zones
-                  if (gdnsd__zones|d([]) | length) > 0
-                  else [ {"reverse_zone": gdnsd__default_reverse_zone} ] }}'
+  when: (item.auto_reverse_zone|d(gdnsd__auto_reverse_zone) and
+         item.domain|d('') | length > 0) or
+        (item.reverse_zone|d('') | length > 0)
+  loop: '{{ gdnsd__zones
+            if (gdnsd__zones | length) > 0
+            else [ {"reverse_zone": gdnsd__default_reverse_zone} ] }}'
+  loop_control:
+    label: '{{ item.reverse_zone|d(gdnsd__default_reverse_zone) }}'
 
 - name: Check configuration and zone files
   command: gdnsd -s checkconf  # noqa 301

--- a/tasks/zone.yml
+++ b/tasks/zone.yml
@@ -1,0 +1,39 @@
+---
+
+- name: Read existing forward zone file hash
+  shell: 'grep "^; Hash:" /etc/gdnsd/zones/{{ gdnsd__include_zone.domain }} || true'
+  changed_when: False
+  check_mode: no
+  register: gdnsd__register_forward_zone_hash
+  when: ('domain' in gdnsd__include_zone.keys())
+
+- name: Generate forward zone file
+  template:
+    src: 'etc/gdnsd/zones/forward_zone.j2'
+    dest: '/etc/gdnsd/zones/{{ gdnsd__include_zone.domain }}'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  when: ('domain' in gdnsd__include_zone.keys())
+
+- name: Read existing reverse zone file hash
+  shell: 'grep "^; Hash:" /etc/gdnsd/zones/{{ gdnsd__include_zone.reverse_zone
+                                              if "reverse_zone" in gdnsd__include_zone.keys()
+                                              else gdnsd__default_reverse_zone }} || true'
+  changed_when: False
+  check_mode: no
+  register: gdnsd__register_reverse_zone_hash
+  when: ('reverse_zone' in gdnsd__include_zone.keys()) or
+        (gdnsd__include_zone['auto_reverse_zone']|d(gdnsd__auto_reverse_zone))
+
+- name: Generate reverse zone file
+  template:
+    src: 'etc/gdnsd/zones/reverse_zone.j2'
+    dest: '/etc/gdnsd/zones/{{ gdnsd__include_zone.reverse_zone
+                               if "reverse_zone" in gdnsd__include_zone.keys()
+                               else gdnsd__default_reverse_zone }}'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  when: ('reverse_zone' in gdnsd__include_zone.keys()) or
+        (gdnsd__include_zone['auto_reverse_zone']|d(gdnsd__auto_reverse_zone))

--- a/templates/etc/gdnsd/zones/forward_zone.j2
+++ b/templates/etc/gdnsd/zones/forward_zone.j2
@@ -4,20 +4,20 @@
  #  way the serial will only be updated if there are some content changes.
  #}
 {% set _zone_data = {} %}
-{% set _ = _zone_data.update({'ttl': item.ttl|d(gdnsd__ttl)}) %}
-{% set _ = _zone_data.update({'domain': item.domain}) %}
-{% set _ = _zone_data.update({'mname': item.primary_nameserver|d(ansible_hostname + '.' + _zone_data['domain'])}) %}
-{% set _ = _zone_data.update({'rname': (item.mailbox|d(gdnsd__mailbox)) + ('' if (item.mailbox|d(gdnsd__mailbox) | regex_search('\.')) else ('.' + _zone_data['domain']))}) %}
-{% set _ = _zone_data.update({'refresh': item.refresh|d(gdnsd__refresh)}) %}
-{% set _ = _zone_data.update({'retry': item.retry|d(gdnsd__retry)}) %}
-{% set _ = _zone_data.update({'expire': item.expire|d(gdnsd__expire)}) %}
-{% set _ = _zone_data.update({'minimum': item.negative_cache|d(gdnsd__negative_cache)}) %}
+{% set _ = _zone_data.update({'ttl': gdnsd__include_zone.ttl|d(gdnsd__ttl)}) %}
+{% set _ = _zone_data.update({'domain': gdnsd__include_zone.domain}) %}
+{% set _ = _zone_data.update({'mname': gdnsd__include_zone.primary_nameserver|d(ansible_hostname + '.' + _zone_data['domain'])}) %}
+{% set _ = _zone_data.update({'rname': (gdnsd__include_zone.mailbox|d(gdnsd__mailbox)) + ('' if (gdnsd__include_zone.mailbox|d(gdnsd__mailbox) | regex_search('\.')) else ('.' + _zone_data['domain']))}) %}
+{% set _ = _zone_data.update({'refresh': gdnsd__include_zone.refresh|d(gdnsd__refresh)}) %}
+{% set _ = _zone_data.update({'retry': gdnsd__include_zone.retry|d(gdnsd__retry)}) %}
+{% set _ = _zone_data.update({'expire': gdnsd__include_zone.expire|d(gdnsd__expire)}) %}
+{% set _ = _zone_data.update({'minimum': gdnsd__include_zone.negative_cache|d(gdnsd__negative_cache)}) %}
 {% set _ = _zone_data.update({'records': []}) %}
 {#
  #  Make sure there is at least one NS entry.
  #}
-{% if item.nameservers|d([]) %}
-{%   for _ns in item.nameservers %}
+{% if gdnsd__include_zone.nameservers|d([]) %}
+{%   for _ns in gdnsd__include_zone.nameservers %}
 {%     set _ = _zone_data['records'].append({'name': '@', 'type': 'NS', 'nsdname': _ns}) %}
 {%   endfor %}
 {% else %}
@@ -26,8 +26,8 @@
 {#
  #  Add host records. If no host records are defined, at least add ourself as a A record.
  #}
-{% if 'records' in item %}
-{%   for _entry in item.records %}
+{% if 'records' in gdnsd__include_zone %}
+{%   for _entry in gdnsd__include_zone.records %}
 {%     set _rr = {'type': _entry.type|d('A'), 'target': _entry.target} %}
 {%     for _key in [ 'name', 'port', 'preference', 'ttl', 'weight' ] %}
 {%       if _key in _entry %}
@@ -44,16 +44,18 @@
  #  accordingly
  #}
 {% set _zone = {'hash': _zone_data | string | hash('md5')} %}
-{% for _result in gdnsd__register_forward_hashes.results %}
-{%   if _result.item.domain == _zone_data['domain'] %}
-{%     set _hash_serial = _result.stdout.split(' ')[2:] %}
-{%     if _hash_serial and _hash_serial[0] == _zone['hash'] %}
-{%       set _ = _zone.update({'serial': _hash_serial[1]}) %}
-{%     else %}
-{%       set _ = _zone.update({'serial': gdnsd__fact_zone_serial}) %}
-{%     endif %}
+{% if gdnsd__register_forward_zone_hash.stdout | length > 0 %}
+{%   set _hash_serial = gdnsd__register_forward_zone_hash.stdout.split(' ')[2:] %}
+{#
+ #   If the hash hasn't change since the last update also re-use the existing serial
+ #}
+{%   if _hash_serial and _hash_serial[0] == _zone['hash'] %}
+{%     set _ = _zone.update({'serial': _hash_serial[1]}) %}
 {%   endif %}
-{% endfor %}
+{% endif %}
+{% if 'serial' not in _zone.keys() %}
+{%   set _ = _zone.update({'serial': gdnsd__fact_zone_serial}) %}
+{% endif %}
 {#
  #  Eventually output the zone data
  #}

--- a/templates/etc/gdnsd/zones/reverse_zone.j2
+++ b/templates/etc/gdnsd/zones/reverse_zone.j2
@@ -4,18 +4,18 @@
  #  way the serial will only be updated if there are some content changes.
  #}
 {% set _zone_data = {} %}
-{% set _ = _zone_data.update({'ttl': item.ttl|d(gdnsd__ttl)}) %}
-{% set _ = _zone_data.update({'domain': item.domain|d(ansible_domain)}) %}
-{% set _ = _zone_data.update({'reverse_zone': item.reverse_zone|d(gdnsd__default_reverse_zone)}) %}
-{% set _ = _zone_data.update({'mname': item.primary_nameserver|d(ansible_hostname + '.' + _zone_data['domain'])}) %}
-{% set _ = _zone_data.update({'rname': (item.mailbox|d(gdnsd__mailbox)) + ('' if (item.mailbox|d(gdnsd__mailbox) | regex_search('\.')) else ('.' + _zone_data['domain']))}) %}
-{% set _ = _zone_data.update({'refresh': item.refresh|d(gdnsd__refresh)}) %}
-{% set _ = _zone_data.update({'retry': item.retry|d(gdnsd__retry)}) %}
-{% set _ = _zone_data.update({'expire': item.expire|d(gdnsd__expire)}) %}
-{% set _ = _zone_data.update({'minimum': item.negative_cache|d(gdnsd__negative_cache)}) %}
+{% set _ = _zone_data.update({'ttl': gdnsd__include_zone.ttl|d(gdnsd__ttl)}) %}
+{% set _ = _zone_data.update({'domain': gdnsd__include_zone.domain|d(ansible_domain)}) %}
+{% set _ = _zone_data.update({'reverse_zone': gdnsd__include_zone.reverse_zone|d(gdnsd__default_reverse_zone)}) %}
+{% set _ = _zone_data.update({'mname': gdnsd__include_zone.primary_nameserver|d(ansible_hostname + '.' + _zone_data['domain'])}) %}
+{% set _ = _zone_data.update({'rname': (gdnsd__include_zone.mailbox|d(gdnsd__mailbox)) + ('' if (gdnsd__include_zone.mailbox|d(gdnsd__mailbox) | regex_search('\.')) else ('.' + _zone_data['domain']))}) %}
+{% set _ = _zone_data.update({'refresh': gdnsd__include_zone.refresh|d(gdnsd__refresh)}) %}
+{% set _ = _zone_data.update({'retry': gdnsd__include_zone.retry|d(gdnsd__retry)}) %}
+{% set _ = _zone_data.update({'expire': gdnsd__include_zone.expire|d(gdnsd__expire)}) %}
+{% set _ = _zone_data.update({'minimum': gdnsd__include_zone.negative_cache|d(gdnsd__negative_cache)}) %}
 {% set _ = _zone_data.update({'nameservers': []}) %}
-{% if item.nameservers|d([]) %}
-{%   for _ns in item.nameservers %}
+{% if gdnsd__include_zone.nameservers|d([]) %}
+{%   for _ns in gdnsd__include_zone.nameservers %}
 {%     set _ = _zone_data['nameservers'].append(_ns + ('' if (_ns | regex_search('\.')) else ('.' + _zone_data['domain']))) %}
 {%   endfor %}
 {% else %}
@@ -29,11 +29,11 @@
  #  Only create reverse entries if this is a reverse zone.
  #}
 {% set _ = _zone_data.update({'records': []}) %}
-{% if ('records' in item) and
-      (('reverse_zone' in item and item.reverse_zone) or (_zone_data['reverse_zone'] == gdnsd__default_reverse_zone)) %}
-{%   for _entry in item.records %}
+{% if ('records' in gdnsd__include_zone) and
+      (('reverse_zone' in gdnsd__include_zone and gdnsd__include_zone.reverse_zone) or (_zone_data['reverse_zone'] == gdnsd__default_reverse_zone)) %}
+{%   for _entry in gdnsd__include_zone.records %}
 {#
- #  Add a PTR entry if record type is 'A', `item.do_reverse` is not False
+ #  Add a PTR entry if record type is 'A', `gdnsd__include_zone.do_reverse` is not False
  #  and it's not a wildcard record.
  #}
 {%     if (('type' in _entry and _entry.type == 'A') or (not 'type' in _entry)) and
@@ -61,17 +61,18 @@
  #  accordingly
  #}
 {% set _zone = {'hash': _zone_data | string | hash('md5')} %}
-{% for _result in gdnsd__register_reverse_hashes.results %}
-{%   if ('reverse_zone' in _result.item and (_result.item.reverse_zone == _zone_data['reverse_zone'])) or
-        (_zone_data['reverse_zone'] == gdnsd__default_reverse_zone) %}
-{%     set _hash_serial = _result.stdout.split(' ')[2:] %}
-{%     if _hash_serial and _hash_serial[0] == _zone['hash'] %}
-{%       set _ = _zone.update({'serial': _hash_serial[1]}) %}
-{%     else %}
-{%       set _ = _zone.update({'serial': gdnsd__fact_zone_serial}) %}
-{%     endif %}
+{% if gdnsd__register_reverse_zone_hash.stdout | length > 0 %}
+{%   set _hash_serial = gdnsd__register_reverse_zone_hash.stdout.split(' ')[2:] %}
+{#
+ #   If the hash hasn't change since the last update also re-use the existing serial
+ #}
+{%   if _hash_serial[0] == _zone['hash'] %}
+{%     set _ = _zone.update({'serial': _hash_serial[1]}) %}
 {%   endif %}
-{% endfor %}
+{% endif %}
+{% if 'serial' not in _zone.keys() %}
+{%   set _ = _zone.update({'serial': gdnsd__fact_zone_serial}) %}
+{% endif %}
 {#
  #  Eventually output the zone data
  #}

--- a/templates/etc/gdnsd/zones/reverse_zone.j2
+++ b/templates/etc/gdnsd/zones/reverse_zone.j2
@@ -42,7 +42,7 @@
 {%       if _net_tuples < 3 %}
 {%         set _ = _zone_data['records'].append({'name': _entry.target.split('.')[_net_tuples:4] | reverse | join('.'), 'ptrdname': _entry.name + ('' if (_entry.name | regex_search('\.')) else ('.' + _zone_data['domain']))}) %}
 {%       else %}
-{%         set _ = _zone_data['records'].append({'name': _entry.target.split('.')[3], 'ptrdname': _entry.name + ('' if (_entry.name | regex_search('\.')) else ('.' + _zone_data['domain']))}) %}
+{%         set _ = _zone_data['records'].append({'name': _entry.target.split('.')[3], 'ptrdname': (_entry.name if (_entry.name != '@') else _zone_data['domain'] ) + ('' if (_entry.name | regex_search('\.')) else ('.' + _zone_data['domain']))}) %}
 {%       endif %}
 {%     endif %}
 {%   endfor %}

--- a/templates/etc/gdnsd/zones/reverse_zone.j2
+++ b/templates/etc/gdnsd/zones/reverse_zone.j2
@@ -33,10 +33,12 @@
       (('reverse_zone' in item and item.reverse_zone) or (_zone_data['reverse_zone'] == gdnsd__default_reverse_zone)) %}
 {%   for _entry in item.records %}
 {#
- #  Add a PTR entry if record type is 'A' and `item.do_reverse` is not False.
+ #  Add a PTR entry if record type is 'A', `item.do_reverse` is not False
+ #  and it's not a wildcard record.
  #}
 {%     if (('type' in _entry and _entry.type == 'A') or (not 'type' in _entry)) and
-          (('do_reverse' in _entry and _entry.do_reverse) or (not 'do_reverse' in _entry)) %}
+          (('do_reverse' in _entry and _entry.do_reverse) or (not 'do_reverse' in _entry)) and
+          (not '*' in _entry.name) %}
 {%       if _net_tuples < 3 %}
 {%         set _ = _zone_data['records'].append({'name': _entry.target.split('.')[_net_tuples:4] | reverse | join('.'), 'ptrdname': _entry.name + ('' if (_entry.name | regex_search('\.')) else ('.' + _zone_data['domain']))}) %}
 {%       else %}


### PR DESCRIPTION
This is the first step of a zone file creation refactoring/simplification that already fixes some obvious and non-obvious issues:
- Fixes various issues with reverse zone file (e.g. fixes #4)
- Replace global `gdnsd__reverse_zones` with `gdnsd__auto_reverse_zone` and zone-specific `auto_reverse_zone` attribute which allows to enable/disable reverse DNS support per zone
- Clean-up documentation of unused `reverse_network` attribute
- Fix description of `reverse_zone` attribute to match use in code
- Use Ansible `loop` construct instead of ancient `with_items` and simplify task output
- Add test for wildcard A record definition