### PR TITLE
Add support for CAA resource records

### DIFF
--- a/docs/defaults-detailed.rst
+++ b/docs/defaults-detailed.rst
@@ -73,8 +73,9 @@ YAML dictionary with the following parameters:
     record type, this is e.g. a host name.
 
   ``type``
-    Optional. Record type. Supported are ``A``, ``AAAA``, ``CAA``, ``CNAME``,
-    ``MX``, ``SRV`` and ``TXT``. Defaults to ``A`` record.
+    Optional. Record type. Supported are ``A``, ``AAAA``, ``CAA``
+    (:program:`gdnsd` >= 2.3.0), ``CNAME``, ``MX``, ``SRV`` and ``TXT``.
+    Defaults to ``A`` record.
 
   ``do_reverse``
     Optional. If ``item.type`` is ``A``, add a reverse zone entry for this

--- a/docs/defaults-detailed.rst
+++ b/docs/defaults-detailed.rst
@@ -73,8 +73,8 @@ YAML dictionary with the following parameters:
     record type, this is e.g. a host name.
 
   ``type``
-    Optional. Record type. Supported are ``A``, ``AAAA``, ``CNAME``, ``MX``,
-    ``SRV`` and ``TXT``. Defaults to ``A`` record.
+    Optional. Record type. Supported are ``A``, ``AAAA``, ``CAA``, ``CNAME``,
+    ``MX``, ``SRV`` and ``TXT``. Defaults to ``A`` record.
 
   ``do_reverse``
     Optional. If ``item.type`` is ``A``, add a reverse zone entry for this
@@ -101,3 +101,8 @@ YAML dictionary with the following parameters:
   ``port``
     Required. The port on this target host of this service. Only valid for
     ``SRV`` record type.
+
+  ``flag``
+    Optional. Only valid for ``CAA`` record type. Set to ``1`` to indicate the
+    *Issuer Critical* flag. Defaults to ``0``. For more information see
+    `RFC6844 <https://tools.ietf.org/html/rfc6844>`_.

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -61,6 +61,14 @@
           - name: ansible
             type: TXT
             target: 'tested-by=molecule'
+          # 'CAA' records
+          - name: '@'
+            type: CAA
+            target: 'iodef "mailto:hostmaster@example.com"'
+          - name: '@'
+            type: CAA
+            flag: 0
+            target: 'issue "letsencrypt.org"'
 
   roles:
     - role: ganto.gdnsd

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -3,6 +3,30 @@
   hosts: all
 
   tasks:
+    # Enable backports to have at least gdnsd-2.3.0 (CAA support)
+    - name: Enable Debian stretch-backports repository
+      lineinfile:
+        path: /etc/apt/sources.list
+        regexp: '^(.*)stretch-backports(.*)$'
+        line: 'deb http://deb.debian.org/debian stretch-backports main'
+      when:
+        - ansible_distribution == 'Debian'
+        - ansible_distribution_release == 'stretch'
+
+    - name: Use gdnsd from stretch-backports
+      copy:
+        content: |
+          Package: gdnsd
+          Pin: release a=stretch-backports
+          Pin-Priority: 500
+        dest: /etc/apt/preferences.d/gdnsd.pref
+        owner: root
+        group: root
+        mode: '0644'
+      when:
+        - ansible_distribution == 'Debian'
+        - ansible_distribution_release == 'stretch'
+
     - name: Update apt cache
       apt:
         update_cache: yes

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -76,6 +76,9 @@
         response: '0 100 389 {{ ansible_hostname }}.example.com.'
       - query: '{{ lookup("dig", "ansible.example.com.", "qtype=TXT", "@" + ansible_default_ipv4.address) }}'
         response: 'tested-by=molecule'
+        # dig doesn't natively support CAA records therefore we have to pass the raw RR type (257)
+      - query: '{{ lookup("dig", "example.com.", "qtype=type257", "@" + ansible_default_ipv4.address, wantlist=True) }}'
+        response: ['0 iodef "mailto:hostmaster@example.com"', '0 issue "letsencrypt.org"']
       - query: '{{ lookup("dig", "192.168.200.1", "qtype=PTR", "@" + ansible_default_ipv4.address) }}'
         response: '{{ ansible_hostname }}.example.com.'
       - query: '{{ lookup("dig", "192.168.200.2", "qtype=PTR", "@" + ansible_default_ipv4.address) }}'

--- a/templates/zone.j2
+++ b/templates/zone.j2
@@ -36,7 +36,7 @@
 {%   for _record in gdnsd__include_zone.records %}
 {%     if gdnsd__fact_zone_type == 'forward' %}
 {%       set _rr = {'type': _record.type|d('A'), 'target': _record.target} %}
-{%       for _key in [ 'name', 'port', 'preference', 'ttl', 'weight' ] %}
+{%       for _key in [ 'name', 'port', 'preference', 'ttl', 'weight', 'flag' ] %}
 {%         if _key in _record.keys() %}
 {%           set _ = _rr.update({_key: _record[_key]}) %}
 {%         endif %}
@@ -113,6 +113,8 @@ $TTL {{ _zone_data['ttl'] }}
 {% for _record in _zone_data['records'] %}
 {%   if (_record['type'] in ['A', 'AAAA', 'PTR', 'TXT']) %}
 {{     _record['name'] }} {{ _record['ttl']|d('') }} IN {{ _record['type'] }} {{ _record['target'] }}
+{%   elif _record['type'] == 'CAA' %}
+{{     _record['name'] }} {{ _record['ttl']|d('') }} IN {{ _record['type'] }} {{ _record['flag']|d(0) }} {{ _record['target'] }}
 {%   elif _record['type'] == 'CNAME' %}
 {{     _record['name'] }} {{ _record['ttl']|d('') }} IN {{ _record['type'] }} {{ _record['target'] }}{{ '.' if (_record['target'] | regex_search('\.')) else '' }}
 {%   elif _record['type'] == 'MX' %}


### PR DESCRIPTION
This also enables the `strech-backports` repository on the Debian Stretch CI job to get `gdnsd-2.3.0` that supports the CAA record type.