### PR TITLE
Yet another ansible-lint fix

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,2 +1,3 @@
 warn_list:
+  - name[template]
   - var-spacing


### PR DESCRIPTION
Disable "name[template]" rule: Jinja templates should only be at the end of 'name'