### PR TITLE
molecule: Fix check for Bullseye on older Debian releases

### DIFF
--- a/molecule/podman/converge.yml
+++ b/molecule/podman/converge.yml
@@ -79,7 +79,7 @@
         file: vars/gdnsd-3.4.yml
       when:
         - ansible_os_family == 'Debian'
-        - ansible_distribution_version != "10"
+        - ansible_distribution_major_version|int > 10
 
   roles:
     - role: ganto.gdnsd


### PR DESCRIPTION
Should fix #23 