### PR TITLE
Use Python 3.13 until ansible-core-2.20 is released

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python 3.
         uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          python-version: '3.13'
 
       - name: Install test dependencies.
         run: pip3 install yamllint ansible-lint[community]
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Python 3.
         uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          python-version: '3.13'
 
       - name: Install test dependencies.
         run: pip3 install -r molecule/docker/requirements.txt
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Python 3.
         uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          python-version: '3.13'
 
       - name: Install documentation dependencies.
         run: pip3 install -r requirements.txt


### PR DESCRIPTION
Fixes:
```
RuntimeError: Python 3.14 requires ansible-core version >= 2.20.0, and  we found 2.19.3.
```