### PR TITLE
molecule: Fix invalid podman config 'cgroupns_mode'

### DIFF
--- a/molecule/podman/molecule.yml
+++ b/molecule/podman/molecule.yml
@@ -14,7 +14,6 @@ platforms:
     pre_build_image: True
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     privileged: True
-    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
 provisioner:


### PR DESCRIPTION
molecule-plugins v26.7.15 introduced a config schema validation: https://github.com/ansible-community/molecule-plugins/pull/335